### PR TITLE
Increase max expression size

### DIFF
--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -51,6 +51,7 @@ interface PostListProps {
   onPostClick?: (post: PostRow) => void;
   onCommentClick?: (post: PostRow) => void;
   highlights?: Record<string, PostHighlight>;
+  postMaxHeight?: number;
 }
 
 function getLengthCategoryChip(expression: string): string | null {
@@ -72,6 +73,7 @@ export function PostList({
   onPostClick,
   onCommentClick,
   highlights,
+  postMaxHeight,
 }: Readonly<PostListProps>) {
   const { toggle, stop, isPlaying } = useBytebeatPlayer();
   const [activePostId, setActivePostId] = useState<string | null>(null);
@@ -454,6 +456,7 @@ export function PostList({
                 onTogglePlay={() => handleExpressionClick(post)}
                 disableCopy={post.license === 'all-rights-reserved'}
                 skipMinification={skipMinification}
+                height={postMaxHeight}
               />
               <div className="post-actions">
                 <button

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-export const EXPRESSION_MAX = 4096;
+export const EXPRESSION_MAX = 16384;
 export const CURRENT_TOS_VERSION = '2025-12-17-v1';
 export const DEBOUNCE_CODE_MS = 200;
 export const POST_DESCRIPTION_MAX = 256;

--- a/src/pages/explore.tsx
+++ b/src/pages/explore.tsx
@@ -605,6 +605,7 @@ export default function ExplorePage() {
                   currentUserId={user ? (user as any).id : undefined}
                   onPostClick={handlePostClick}
                   onCommentClick={handleCommentClick}
+                  postMaxHeight={250}
                 />
               </div>
             )}

--- a/supabase/migrations/065_increase_expression_max_to_16384.sql
+++ b/supabase/migrations/065_increase_expression_max_to_16384.sql
@@ -1,0 +1,11 @@
+-- Increase expression byte limit from 4096 to 16384
+ALTER TABLE public.posts
+  DROP CONSTRAINT IF EXISTS expression_max_length;
+
+ALTER TABLE public.posts
+  ADD CONSTRAINT expression_max_length
+  CHECK (
+    is_draft = true
+    OR public.minified_byte_length(expression) <= 16384
+  )
+  NOT VALID;


### PR DESCRIPTION
Extend the max expression byte count to 16384 (https://github.com/pckerneis/BytebeatCloud/issues/61)